### PR TITLE
Fix Groovy 2.x examples parent relative path + remove redundant version

### DIFF
--- a/examples/groovy-2.x/pom.xml
+++ b/examples/groovy-2.x/pom.xml
@@ -5,13 +5,13 @@
     <groupId>org.jboss.arquillian.spock</groupId>
     <artifactId>arquillian-spock-parent</artifactId>
     <version>1.0.0.Final-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.jboss.arquillian.spock</groupId>
   <artifactId>arquillian-spock-example-groovy-2.x</artifactId>
-  <version>1.0.0.Final-SNAPSHOT</version>
   <name>Arquillian TestRunner Spock Example: Groovy 2.x</name>
   <description>Examples of using Spock with Arquillian</description>
   <url>http://arquillian.org</url>


### PR DESCRIPTION
I fixed the Maven build.
  * Without the relative path a build is impossible.
  * Cosmetics: The removed version is redundant (should use the parent version).

Relates to #18.