### PR TITLE
update from upstream (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ test-output/
 # JBoss AS
 transaction.log
 
+.autoenv.zsh
+

--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ You must annotate the JUnit Runner with the ArquillianSputnik runner.
 
 ### More info
 
-[Spock](http://spockframework.org/)
-[Arquillian](http://jboss.org/arquillian/)
+[Spock](http://spockframework.github.io/spock/docs/)
+[Arquillian](http://arquillian.org/)
                              

--- a/container/src/main/java/org/jboss/arquillian/spock/container/SpockTestRunner.java
+++ b/container/src/main/java/org/jboss/arquillian/spock/container/SpockTestRunner.java
@@ -16,17 +16,16 @@
  */
 package org.jboss.arquillian.spock.container;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.jboss.arquillian.container.test.spi.TestRunner;
 import org.jboss.arquillian.spock.ArquillianSputnik;
 import org.jboss.arquillian.test.spi.TestResult;
-import org.jboss.arquillian.test.spi.TestResult.Status;
 import org.junit.runner.Result;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 import org.spockframework.runtime.Sputnik;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Spock TestRunner
@@ -63,7 +62,7 @@ public class SpockTestRunner implements TestRunner
       }
       catch (Exception e)
       {
-         return new TestResult(Status.FAILED, e);
+         return TestResult.failed(e);
       }
 
       return convertToTestResult(testResult);
@@ -90,21 +89,21 @@ public class SpockTestRunner implements TestRunner
     */
    private TestResult convertToTestResult(Result result)
    {
-      Status status = Status.PASSED;
+      TestResult newResult = TestResult.passed();
       Throwable throwable = null;
 
       if (result.getFailureCount() > 0)
       {
-         status = Status.FAILED;
          throwable = result.getFailures().get(0).getException();
+         newResult = TestResult.failed(throwable);
       }
 
       if (result.getIgnoreCount() > 0)
       {
-         status = Status.SKIPPED;
+         newResult = TestResult.skipped(throwable);
       }
 
-      return new TestResult(status, throwable);
+      return newResult;
    }
 
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,7 +38,6 @@
     <dependency>
       <groupId>org.jboss.arquillian.core</groupId>
       <artifactId>arquillian-core-impl-base</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -50,7 +49,6 @@
     <dependency>
       <groupId>org.jboss.arquillian.test</groupId>
       <artifactId>arquillian-test-impl-base</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/examples/groovy-1.x/pom.xml
+++ b/examples/groovy-1.x/pom.xml
@@ -36,10 +36,8 @@
       <organizationUrl>http://arquillian.org</organizationUrl>
     </developer>
   </developers>
-
   <properties>
-    <!-- contains JavaEE6, Arquillian and Arquillian AS7 bindings -->
-    <version.org.jboss.bom>1.0.6.Final</version.org.jboss.bom>
+    <version.arquillian_core>1.1.11.Final</version.arquillian_core>
     <!-- JBoss AS7 version to be unpacked -->
     <version.jbossas_7>7.1.1.Final</version.jbossas_7>
 
@@ -56,16 +54,16 @@
     <version.source.plugin>2.2.1</version.source.plugin>
     <version.jar.plugin>2.4</version.jar.plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.surefire.plugin>2.17</version.surefire.plugin>
+    <version.surefire.plugin>2.19.1</version.surefire.plugin>
     <version.gmaven>1.2</version.gmaven>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom</groupId>
-        <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-        <version>${version.org.jboss.bom}</version>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.arquillian_core}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -74,6 +72,13 @@
 
   <!-- Dependencies -->
   <dependencies>
+
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>7.0</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.arquillian.spock</groupId>
@@ -100,6 +105,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
 
@@ -152,11 +158,13 @@
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet</artifactId>
+          <version>${version.arquillian_core}</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.as</groupId>
           <artifactId>jboss-as-arquillian-container-managed</artifactId>
+          <version>${version.jbossas_7}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/examples/groovy-2.x/pom.xml
+++ b/examples/groovy-2.x/pom.xml
@@ -38,8 +38,7 @@
   </developers>
 
   <properties>
-    <!-- contains JavaEE6, Arquillian and Arquillian AS7 bindings -->
-    <version.org.jboss.bom>1.0.6.Final</version.org.jboss.bom>
+    <version.arquillian_core>1.1.11.Final</version.arquillian_core>
     <!-- JBoss AS7 version to be unpacked -->
     <version.jbossas_7>7.1.1.Final</version.jbossas_7>
 
@@ -60,15 +59,15 @@
     <version.source.plugin>2.2.1</version.source.plugin>
     <version.jar.plugin>2.4</version.jar.plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.surefire>2.17</version.surefire>
+    <version.surefire>2.19.1</version.surefire>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.bom</groupId>
-        <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-        <version>${version.org.jboss.bom}</version>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.arquillian_core}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -77,6 +76,13 @@
 
   <!-- Dependencies -->
   <dependencies>
+
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>7.0</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.arquillian.spock</groupId>
@@ -103,6 +109,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
 
@@ -155,11 +162,13 @@
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet</artifactId>
+          <version>${version.arquillian_core}</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.as</groupId>
           <artifactId>jboss-as-arquillian-container-managed</artifactId>
+          <version>${version.jbossas_7}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
     <relativePath />
-    <version>10</version>
+    <version>19</version>
   </parent>
 
   <!-- Model Information -->
@@ -49,15 +49,15 @@
 
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.1.2.Final</version.arquillian_core>
+    <version.arquillian_core>1.1.11.Final</version.arquillian_core>
     <version.spock>0.7-groovy-2.0</version.spock>
     <version.groovy>2.1.5</version.groovy>
-    <version.assertj>1.5.0</version.assertj>
+    <version.assertj>2.2.0</version.assertj>
 
     <!-- override from parent -->
     <version.maven_compiler>3.1</version.maven_compiler>
     <version.release.plugin>2.1</version.release.plugin>
-    <version.maven_surefire>2.16</version.maven_surefire>
+    <version.maven_surefire>2.19.1</version.maven_surefire>
   </properties>
 
   <dependencyManagement>
@@ -65,7 +65,7 @@
       <dependency>
         <groupId>org.jboss.shrinkwrap</groupId>
         <artifactId>shrinkwrap-bom</artifactId>
-        <version>1.1.2</version>
+        <version>1.2.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/standalone/src/main/java/org/jboss/arquillian/spock/standalone/LocalTestMethodExecutor.java
+++ b/standalone/src/main/java/org/jboss/arquillian/spock/standalone/LocalTestMethodExecutor.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.TestResult;
-import org.jboss.arquillian.test.spi.TestResult.Status;
 import org.jboss.arquillian.test.spi.annotation.TestScoped;
 import org.jboss.arquillian.test.spi.event.suite.Test;
 
@@ -46,23 +45,21 @@ public class LocalTestMethodExecutor
    
    public void execute(@Observes Test event) throws Exception 
    {
-      TestResult result = new TestResult();
+      TestResult result = TestResult.passed();
       try 
       {
          event.getTestMethodExecutor().invoke(
                enrichArguments(
                      event.getTestMethod(), 
                      serviceLoader.get().all(TestEnricher.class)));
-         result.setStatus(Status.PASSED);
-      } 
+      }
       catch (Throwable e) 
       {
-         result.setStatus(Status.FAILED);
-         result.setThrowable(e);
+         result = TestResult.failed(e);
       }
       finally 
       {
-         result.setEnd(System.currentTimeMillis());         
+         result.setEnd(System.currentTimeMillis());
       }
       testResult.set(result);
    }
@@ -71,7 +68,7 @@ public class LocalTestMethodExecutor
     * Enrich the method arguments of a method call.<br/>
     * The Object[] index will match the method parameterType[] index.
     * 
-    * @param method
+    * @param method method to enrich arguments
     * @return the argument values
     */
    private Object[] enrichArguments(Method method, Collection<TestEnricher> enrichers)


### PR DESCRIPTION
* Updated gitignore to not track autoenv files

* Updated Arquillian Core, AssertJ, Shrinkwrap BOM, JBoss Parent and bunch of maven plugins

* Fixes deprecation warnings about TestResult.

* Changes links in the README.md

Spock refers now to the documentation
Arquillian to the official page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-testrunner-spock/33)
<!-- Reviewable:end -->
